### PR TITLE
fix: use correct ID for grade tooltip for proper translations

### DIFF
--- a/src/course-home/progress-tab/grades/messages.ts
+++ b/src/course-home/progress-tab/grades/messages.ts
@@ -204,7 +204,7 @@ const messages = defineMessages({
     description: 'It the text precede the sum of weighted grades of all the assignment',
   },
   weightedGradeSummaryTooltip: {
-    id: 'progress.weightedGradeSummary',
+    id: 'progress.weightedGradeSummaryTooltip',
     defaultMessage: 'Your raw weighted grade summary is {rawGrade} and rounds to {roundedGrade}.',
     description: 'Tooltip content that explains the rounding of the summary versus individual assignments',
   },


### PR DESCRIPTION
## Description

The tooltip message ID should be `weightedGradeSummaryTooltip` instead of the duplicated `weightedGradeSummary` so messages are shown and translated properly